### PR TITLE
Update CLI

### DIFF
--- a/Installation/CLI.md
+++ b/Installation/CLI.md
@@ -1,7 +1,5 @@
 # Windows
-
-On Windows, the GitHub CLI is available via ![scoop](https://scoop.sh/), ![Chocolatey](https://chocolatey.org/), and as downloadable MSI.
-
+On Windows, the GitHub CLI is available via [Scoop](https://scoop.sh/), [Chocolatey](https://chocolatey.org/), and as downloadable MSI.
 #### scoop
 
 Install:


### PR DESCRIPTION
This is a simpe edit to the Github CLI documentation as it concerns the Windows installation of the CLI. 
The previous edit had the "scoop" and "Chocolatey" methods links not directing well.
This edit now corrects this and has the two methods direcing to their respective web pages.