### PR TITLE
Spell Correction and Missing origin name : Issue #33

### DIFF
--- a/Guides/creating_a_pull_request.md
+++ b/Guides/creating_a_pull_request.md
@@ -13,23 +13,26 @@
     ![Code Button](/images/code-button.png)   
     Click the clipboard button to copy the repository web URL.    
     ![Clone Button](/images/https-url-clone.png)  
-    In your terminal type `$ git clone https://github.com/YOUR-USERNAME/YOUR-REPOSITORY`.  
+    In your terminal type `$ git clone https://github.com/<YOUR-USERNAME>/<ORIGINAL-REPOSITORY-NAME>`.  
     This creates a local repository from your remote one.
     
 4. #### Make a new branch.
-    Open your newly cloned repository by typing `$ cd YOUR-REPOSITORY`.  
-    Then type `$ git chekcout -b BRANCH-NAME` to create a new branch.
+    Open your newly cloned repository by typing `$ cd ORIGINAL-REPOSITORY-NAME`.  
+    Then type `$ git checkout -b <BRANCH-NAME>` to create a new branch.
     
 5. #### Make your changes.
     Open up the project by typing `$ code .`, and make the appropriate changes.
+    You can alternatively open the repository in any other IDE too.
     
 6. #### Push it back to your repo.
     Add your changes by typing `$ git add .`.  
-    Then add a commit message by typing `$ git commit -m "YOUR-MESSAGE"`.  
-    Lastly, type `$ git push` to push all of your changes back to your remote repository.
+    Then add a commit message by typing `$ git commit -m "YOUR-COMMIT-MESSAGE"`.  
+    Lastly, type `$ git push origin <BRANCH-NAME>` to push all of your changes back to your remote repository.
+    ##### Note : Do Not Make Changes in the Master branch
     
 7. #### Click Create pull request to open a new pull request.
-    Navigate back to your forked repository on GitHub.  
+    Navigate back to your forked repository on GitHub.
+    You can now see a "Create Pull Request" button on the main page.
     Click the "Pull requests" tab and select "New pull request".  
     Be sure to select the appropriate branch you want to merge from and to.  
     ![Create Pull Request](/images/choose-base-and-compare-branches.png)


### PR DESCRIPTION
#33 Added few Important Points like
-  `$ git push origin <BRANCH-NAME>` was added
- Spelling of `$ git checkout` was misspelled earlier.
- Added warning of not committing in master branch.

